### PR TITLE
fix(engine): use REDISCLI_AUTH for valkey-cli auth in generated scripts

### DIFF
--- a/operator/redisfailover/service/engine.go
+++ b/operator/redisfailover/service/engine.go
@@ -8,21 +8,26 @@ import (
 type DatabaseEngineProvider interface {
 	ServerBinary() string
 	CLIBinary() string
-	// CLIAuthEnvName is exported before invoking the CLI when REDIS_PASSWORD is set (e.g. REDISCLI_AUTH, VALKEYCLI_AUTH).
+	// CLIAuthEnvName is exported before invoking the CLI when REDIS_PASSWORD is set (REDISCLI_AUTH).
 	CLIAuthEnvName() string
 }
 
 type redisEngine struct{}
 
-func (redisEngine) ServerBinary() string    { return "redis-server" }
-func (redisEngine) CLIBinary() string         { return "redis-cli" }
-func (redisEngine) CLIAuthEnvName() string   { return "REDISCLI_AUTH" }
+func (redisEngine) ServerBinary() string   { return "redis-server" }
+func (redisEngine) CLIBinary() string      { return "redis-cli" }
+func (redisEngine) CLIAuthEnvName() string { return "REDISCLI_AUTH" }
 
 type valkeyEngine struct{}
 
-func (valkeyEngine) ServerBinary() string    { return "valkey-server" }
-func (valkeyEngine) CLIBinary() string       { return "valkey-cli" }
-func (valkeyEngine) CLIAuthEnvName() string { return "VALKEYCLI_AUTH" }
+func (valkeyEngine) ServerBinary() string { return "valkey-server" }
+func (valkeyEngine) CLIBinary() string    { return "valkey-cli" }
+
+// valkey-cli reads REDISCLI_AUTH on every release; VALKEYCLI_AUTH is an alias
+// added only in valkey 9.0 (with REDISCLI_AUTH kept as a permanent fallback),
+// so REDISCLI_AUTH is the one that authenticates on the 7.2 and 8.x images
+// this operator can run — including its own default valkey image.
+func (valkeyEngine) CLIAuthEnvName() string { return "REDISCLI_AUTH" }
 
 // EngineFor returns the engine implementation for pod generation. Empty or Redis uses Redis binaries; Valkey uses Valkey binaries.
 func EngineFor(rf *redisfailoverv1.RedisFailover) DatabaseEngineProvider {

--- a/operator/redisfailover/service/engine_test.go
+++ b/operator/redisfailover/service/engine_test.go
@@ -19,7 +19,7 @@ func TestEngineFor(t *testing.T) {
 	}{
 		{"omitted is redis", "", "redis-server", "redis-cli", "REDISCLI_AUTH"},
 		{"redis", redisfailoverv1.RedisEngine, "redis-server", "redis-cli", "REDISCLI_AUTH"},
-		{"valkey", redisfailoverv1.ValkeyEngine, "valkey-server", "valkey-cli", "VALKEYCLI_AUTH"},
+		{"valkey", redisfailoverv1.ValkeyEngine, "valkey-server", "valkey-cli", "REDISCLI_AUTH"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/integration/redisfailover/database_engine_test.go
+++ b/test/integration/redisfailover/database_engine_test.go
@@ -185,10 +185,10 @@ func (c *clients) testValkeyWorkloadBinaries(t *testing.T, currentNamespace, rfN
 	shutdownCM, err := c.k8sClient.CoreV1().ConfigMaps(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-s-%s", rfName), metav1.GetOptions{})
 	require.NoError(err)
 	assert.Contains(shutdownCM.Data["shutdown.sh"], "valkey-cli")
-	assert.Contains(shutdownCM.Data["shutdown.sh"], "VALKEYCLI_AUTH")
+	assert.Contains(shutdownCM.Data["shutdown.sh"], "REDISCLI_AUTH")
 
 	readinessCM, err := c.k8sClient.CoreV1().ConfigMaps(currentNamespace).Get(context.Background(), fmt.Sprintf("rfr-readiness-%s", rfName), metav1.GetOptions{})
 	require.NoError(err)
 	assert.Contains(readinessCM.Data["ready.sh"], "valkey-cli")
-	assert.Contains(readinessCM.Data["ready.sh"], "VALKEYCLI_AUTH")
+	assert.Contains(readinessCM.Data["ready.sh"], "REDISCLI_AUTH")
 }


### PR DESCRIPTION
## Problem

For the Valkey engine, the generated readiness and shutdown scripts authenticate `valkey-cli` by exporting `VALKEYCLI_AUTH=${REDIS_PASSWORD}` (`valkeyEngine.CLIAuthEnvName()`). But `valkey-cli` did not read that variable until valkey 9.0 — it reads `REDISCLI_AUTH` (the name inherited from redis). valkey 9.0.0 added `VALKEYCLI_AUTH` as the primary name and kept `REDISCLI_AUTH` as a permanent fallback, so on every earlier release `VALKEYCLI_AUTH` is simply ignored.

That includes the images this operator runs against by default: `EngineFor` → `valkeyEngine`, and `defaultValkeyImage` is `valkey/valkey:7.2.11-alpine`, whose `valkey-cli` reads `REDISCLI_AUTH` only. So with `auth` enabled, `ready.sh`'s `valkey-cli info replication` returns `NOAUTH Authentication required`, the `role` never matches `role:master`/`role:slave`, the script prints `unexpected` and exits non-zero, and the Redis (Valkey) data StatefulSet never becomes Ready. The Redis engine is unaffected because `redis-cli` reads `REDISCLI_AUTH`.

## Evidence

- valkey source at tag `8.1.8` (`src/valkey-cli.c`): `#define CLI_AUTH_ENV "REDISCLI_AUTH"` — the only auth env var, no `VALKEYCLI_AUTH`.
- valkey source at tag `9.0.0`: `#define CLI_AUTH_ENV "VALKEYCLI_AUTH"` with `#define OLD_CLI_AUTH_ENV "REDISCLI_AUTH"` and `if (!auth) auth = getenv(OLD_CLI_AUTH_ENV);` — 9.0+ reads `VALKEYCLI_AUTH` first, then falls back to `REDISCLI_AUTH`.
- On a running `valkey/valkey:8.1.8`, `valkey-cli --help` documents `REDISCLI_AUTH` and no `VALKEYCLI_AUTH`; `VALKEYCLI_AUTH=<pw> valkey-cli ping` returns `NOAUTH`, while `REDISCLI_AUTH=<pw> valkey-cli ping` returns `PONG`.

## Fix

Return `REDISCLI_AUTH` for the Valkey engine. It is read by `valkey-cli` on every version (7.2 and 8.x directly; 9.0+ via the documented fallback), so the readiness and shutdown scripts authenticate regardless of which valkey image the `RedisFailover` runs. This is a strictly safer choice than `VALKEYCLI_AUTH`, which only works from 9.0 onward.

## Tests

- `operator/redisfailover/service/engine_test.go` — the Valkey table case now expects `REDISCLI_AUTH`.
- `test/integration/redisfailover/database_engine_test.go` — asserts the generated `ready.sh`/`shutdown.sh` carry `REDISCLI_AUTH`.
- `go test ./operator/redisfailover/service/` passes; the integration package compiles under `-tags integration`.

The same one-line change was verified end-to-end on a live cluster (running the operator built from this patch): an auth-enabled Valkey `RedisFailover` that previously hung on `Readiness probe failed: unexpected` reaches `readyReplicas` with the fix in place.
